### PR TITLE
minimum viable clusters: aws

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+# Help Helper matches comments at the start of the task block so make help gives users information about each task
+.PHONY: help
+help: ## Displays information about available make tasks
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+build-clusters: ## Build all clusters in parallel.
+	parallel --ungroup --halt soon,done=100% --term-seq INT,600000 \
+	  './bin/cluster up' ::: team-dev-aws-us team-dev-aws-au
+
+destroy-clusters: ## Tear down all clusters in parallel.
+	parallel --ungroup --halt soon,done=100% --term-seq INT,600000 \
+	  './bin/cluster down' ::: team-dev-aws-us team-dev-aws-au

--- a/bin/cluster
+++ b/bin/cluster
@@ -41,11 +41,11 @@ fi
 echo "[$2]: Spinning $1..."
 cd "${SCRIPT_PATH}/../${CLUSTER_PATH}"
 if [[ $1 == "up" ]]; then
-  workspaces=("network" "cluster" "routing")
+  workspaces=("network" "cluster" "cluster-config" "routing")
   command="apply"
 fi
 if [[ $1 == "down" ]]; then
-  workspaces=("routing" "cluster" "network")
+  workspaces=("cluster-config" "routing" "cluster" "network")
   command="destroy"
 fi
 

--- a/bin/cluster
+++ b/bin/cluster
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# A convenience script for simplifying the process of creating or destroying
+# numerous kubernetes clusters across cloud providers. For demonstration
+# purposes only--not real world infrastructure management.
+set -euo pipefail
+SCRIPT_PATH="$(cd "$(dirname "$BASH_SOURCE[0]")"; pwd -P)"
+
+# ensure terraform exits gracefully if consumer presses ctrl+c
+function graceful-exit {
+  kill -SIGINT "$tfpid"
+  wait $tfpid
+}
+trap 'graceful-exit' SIGINT
+
+function usage {
+  echo "Usage: $0 <up|down> <team-env-provider-region>"
+  exit 1
+}
+
+if test "$#" -ne 2; then
+    usage
+fi
+
+if [[ ("$1" != "up" && "$1" != "down") || -z "$2" ]]; then
+    usage
+fi
+
+IFS='-' read -r -a params <<< "$2"
+
+if [[ "${#params[@]}" != 4 ]]; then
+  echo "Please provide a valid cluster name (e.g. team-dev-aws-us)."
+  exit 1
+fi
+
+CLUSTER_PATH="infrastructure/${params[0]}-${params[1]}/${params[2]}/${params[3]}"
+if [[ ! -d "${SCRIPT_PATH}/../${CLUSTER_PATH}" ]]; then
+  echo "No cluster found in ${CLUSTER_PATH}."
+  exit 1
+fi
+
+echo "[$2]: Spinning $1..."
+cd "${SCRIPT_PATH}/../${CLUSTER_PATH}"
+if [[ $1 == "up" ]]; then
+  workspaces=("network" "cluster" "routing")
+  command="apply"
+fi
+if [[ $1 == "down" ]]; then
+  workspaces=("routing" "cluster" "network")
+  command="destroy"
+fi
+
+for workspace in "${workspaces[@]}"; do
+  (
+    cd ${workspace}
+    terraform init
+    terraform ${command} -auto-approve
+  ) 2>&1 | sed "/^$/!s/^/\[$2\/${workspace}\]: /" &
+  tfpid=$!
+  # -n ensures the loop stops if there are failures in the subshell
+  wait -n
+done

--- a/infrastructure/team-dev/aws/au/cluster-config/.terraform.lock.hcl
+++ b/infrastructure/team-dev/aws/au/cluster-config/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/gavinbunney/kubectl" {
+  version     = "1.14.0"
+  constraints = "1.14.0"
+  hashes = [
+    "h1:gLFn+RvP37sVzp9qnFCwngRjjFV649r6apjxvJ1E/SE=",
+    "zh:0350f3122ff711984bbc36f6093c1fe19043173fad5a904bce27f86afe3cc858",
+    "zh:07ca36c7aa7533e8325b38232c77c04d6ef1081cb0bac9d56e8ccd51f12f2030",
+    "zh:0c351afd91d9e994a71fe64bbd1662d0024006b3493bb61d46c23ea3e42a7cf5",
+    "zh:39f1a0aa1d589a7e815b62b5aa11041040903b061672c4cfc7de38622866cbc4",
+    "zh:428d3a321043b78e23c91a8d641f2d08d6b97f74c195c654f04d2c455e017de5",
+    "zh:4baf5b1de2dfe9968cc0f57fd4be5a741deb5b34ee0989519267697af5f3eee5",
+    "zh:6131a927f9dffa014ab5ca5364ac965fe9b19830d2bbf916a5b2865b956fdfcf",
+    "zh:c62e0c9fd052cbf68c5c2612af4f6408c61c7e37b615dc347918d2442dd05e93",
+    "zh:f0beffd7ce78f49ead612e4b1aefb7cb6a461d040428f514f4f9cc4e5698ac65",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.45.0"
+  constraints = "5.45.0"
+  hashes = [
+    "h1:4Vgk51R7iTY1oczaTQDG+DkA9nE8TmjlUtecqXX6qDU=",
+    "zh:1379bcf45aef3d486ee18b4f767bfecd40a0056510d26107f388be3d7994c368",
+    "zh:1615a6f5495acfb3a0cb72324587261dd4d72711a3cc51aff13167b14531501e",
+    "zh:18b69a0f33f8b1862fbd3f200756b7e83e087b73687085f2cf9c7da4c318e3e6",
+    "zh:2c5e7aecd197bc3d3b19290bad8cf4c390c2c6a77bb165da4e11f53f2dfe2e54",
+    "zh:3794da9bef97596e3bc60e12cdd915bda5ec2ed62cd1cd93723d58b4981905fe",
+    "zh:40a5e45ed91801f83db76dffd467dcf425ea2ca8642327cf01119601cb86021c",
+    "zh:4abfc3f53d0256a7d5d1fa5e931e4601b02db3d1da28f452341d3823d0518f1a",
+    "zh:4eb0e98078f79aeb06b5ff6115286dc2135d12a80287885698d04036425494a2",
+    "zh:75470efbadea4a8d783642497acaeec5077fc4a7f3df3340defeaa1c7de29bf7",
+    "zh:8861a0b4891d5fa2fa7142f236ae613cea966c45b5472e3915a4ac3abcbaf487",
+    "zh:8bf6f21cd9390b742ca0b4393fde92616ca9e6553fb75003a0999006ad233d35",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ad73008a044e75d337acda910fb54d8b81a366873c8a413fec1291034899a814",
+    "zh:bf261713b0b8bebfe8c199291365b87d9043849f28a2dc764bafdde73ae43693",
+    "zh:da3bafa1fd830be418dfcc730e85085fe67c0d415c066716f2ac350a2306f40a",
+  ]
+}

--- a/infrastructure/team-dev/aws/au/cluster-config/config.tf
+++ b/infrastructure/team-dev/aws/au/cluster-config/config.tf
@@ -6,8 +6,6 @@ data "aws_eks_cluster_auth" "this_env" {
   name = local.envName
 }
 
-data "aws_region" "this_env" {}
-
 locals {
   provider  = "aws"
   team      = "team"

--- a/infrastructure/team-dev/aws/au/cluster-config/config.tf
+++ b/infrastructure/team-dev/aws/au/cluster-config/config.tf
@@ -1,0 +1,50 @@
+data "aws_eks_cluster" "this_env" {
+  name = local.envName
+}
+
+data "aws_eks_cluster_auth" "this_env" {
+  name = local.envName
+}
+
+data "aws_region" "this_env" {}
+
+locals {
+  provider  = "aws"
+  team      = "team"
+  env       = "dev"
+  region    = "au"
+  workspace = "cluster-config"
+  envName   = "${local.provider}-${local.team}-${local.env}-${local.region}"
+  name      = "${local.envName}-${local.workspace}"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "=5.45"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "=1.14.0"
+    }
+  }
+  cloud {
+    organization = "scaleout"
+    workspaces {
+      project = "aws-team-dev-au"
+      name    = "aws-team-dev-au-cluster-config"
+    }
+  }
+}
+
+provider "aws" {
+  region  = "ap-southeast-2"
+  profile = "au"
+}
+
+provider "kubectl" {
+  host                   = data.aws_eks_cluster.this_env.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this_env.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.this_env.token
+}

--- a/infrastructure/team-dev/aws/au/cluster-config/install.tf
+++ b/infrastructure/team-dev/aws/au/cluster-config/install.tf
@@ -1,0 +1,4 @@
+resource "kubectl_manifest" "ingress" {
+  for_each  = toset(split("---", file("${path.module}/nginx.yml")))
+  yaml_body = each.value
+}

--- a/infrastructure/team-dev/aws/au/cluster-config/nginx.yml
+++ b/infrastructure/team-dev/aws/au/cluster-config/nginx.yml
@@ -9,7 +9,7 @@ metadata:
   name: nginx-html
   namespace: routing
 data:
-  index.html: aws-us
+  index.html: hello from aws-au!
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -38,16 +38,13 @@ spec:
         volumeMounts:
         - mountPath: /usr/share/nginx/html
           name: nginx-html
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - nginx
-            topologyKey: failure-domain.beta.kubernetes.io/zone
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: nginx
       nodeSelector:
         node.wescaleout.cloud/routing: "true"
       tolerations:

--- a/infrastructure/team-dev/aws/au/cluster/.terraform.lock.hcl
+++ b/infrastructure/team-dev/aws/au/cluster/.terraform.lock.hcl
@@ -1,0 +1,105 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.45.0"
+  constraints = ">= 4.33.0, >= 5.40.0, 5.45.0"
+  hashes = [
+    "h1:4Vgk51R7iTY1oczaTQDG+DkA9nE8TmjlUtecqXX6qDU=",
+    "zh:1379bcf45aef3d486ee18b4f767bfecd40a0056510d26107f388be3d7994c368",
+    "zh:1615a6f5495acfb3a0cb72324587261dd4d72711a3cc51aff13167b14531501e",
+    "zh:18b69a0f33f8b1862fbd3f200756b7e83e087b73687085f2cf9c7da4c318e3e6",
+    "zh:2c5e7aecd197bc3d3b19290bad8cf4c390c2c6a77bb165da4e11f53f2dfe2e54",
+    "zh:3794da9bef97596e3bc60e12cdd915bda5ec2ed62cd1cd93723d58b4981905fe",
+    "zh:40a5e45ed91801f83db76dffd467dcf425ea2ca8642327cf01119601cb86021c",
+    "zh:4abfc3f53d0256a7d5d1fa5e931e4601b02db3d1da28f452341d3823d0518f1a",
+    "zh:4eb0e98078f79aeb06b5ff6115286dc2135d12a80287885698d04036425494a2",
+    "zh:75470efbadea4a8d783642497acaeec5077fc4a7f3df3340defeaa1c7de29bf7",
+    "zh:8861a0b4891d5fa2fa7142f236ae613cea966c45b5472e3915a4ac3abcbaf487",
+    "zh:8bf6f21cd9390b742ca0b4393fde92616ca9e6553fb75003a0999006ad233d35",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ad73008a044e75d337acda910fb54d8b81a366873c8a413fec1291034899a814",
+    "zh:bf261713b0b8bebfe8c199291365b87d9043849f28a2dc764bafdde73ae43693",
+    "zh:da3bafa1fd830be418dfcc730e85085fe67c0d415c066716f2ac350a2306f40a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version     = "2.3.3"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:U6EC4/cJJ6Df3LztUQ/I4YuljGQQeQ+LdLndAwSSiTs=",
+    "zh:0bd6ee14ca5cf0f0c83d3bb965346b1225ccd06a6247e80774aaaf54c729daa7",
+    "zh:3055ad0dcc98de1d4e45b72c5889ae91b62f4ae4e54dbc56c4821be0fdfbed91",
+    "zh:32764cfcff0d7379ca8b7dde376ac5551854d454c5881945f1952b785a312fa2",
+    "zh:55c2a4dc3ebdeaa1dec3a36db96dab253c7fa10b9fe1209862e1ee77a01e0aa1",
+    "zh:5c71f260ba5674d656d12f67cde3bb494498e6b6b6e66945ef85688f185dcf63",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9617280a853ec7caedb8beb7864e4b29faf9c850a453283980c28fccef2c493d",
+    "zh:ac8bda21950f8dddade3e9bc15f7bcfdee743738483be5724169943cafa611f5",
+    "zh:ba9ab567bbe63dee9197a763b3104ea9217ba27449ed54d3afa6657f412e3496",
+    "zh:effd1a7e34bae3879c02f03ed3afa979433a518e11de1f8afd35a8710231ac14",
+    "zh:f021538c86d0ac250d75e59efde6d869bbfff711eb744c8bddce79d2475bf46d",
+    "zh:f1e3984597948a2103391a26600e177b19f16a5a4c66acee27a4343fb141571f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.2"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
+    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
+    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
+    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
+    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
+    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
+    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
+    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
+    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
+    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
+    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.11.1"
+  constraints = ">= 0.9.0"
+  hashes = [
+    "h1:IkDriv5C9G+kQQ+mP+8QGIahwKgbQcw1/mzh9U6q+ZI=",
+    "zh:19a393db736ec4fd024d098d55aefaef07056c37a448ece3b55b3f5f4c2c7e4a",
+    "zh:227fa1e221de2907f37be78d40c06ca6a6f7b243a1ec33ade014dfaf6d92cd9c",
+    "zh:29970fecbf4a3ca23bacbb05d6b90cdd33dd379f90059fe39e08289951502d9f",
+    "zh:65024596f22f10e7dcb5e0e4a75277f275b529daa0bc0daf34ca7901c678ab88",
+    "zh:694d080cb5e3bf5ef08c7409208d061c135a4f5f4cdc93ea8607860995264b2e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b29d15d13e1b3412e6a4e1627d378dbd102659132f7488f64017dd6b6d5216d3",
+    "zh:bb79f4cae9f8c17c73998edc54aa16c2130a03227f7f4e71fc6ac87e230575ec",
+    "zh:ceccf80e95929d97f62dcf1bb3c7c7553d5757b2d9e7d222518722fc934f7ad5",
+    "zh:f40e638336527490e294d9c938ae55919069e6987e85a80506784ba90348792a",
+    "zh:f99ef33b1629a3b2278201142a3011a8489e66d92da832a5b99e442204de18fb",
+    "zh:fded14754ea46fdecc62a52cd970126420d4cd190e598cb61190b4724a727edb",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.0.5"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:e4LBdJoZJNOQXPWgOAG0UuPBVhCStu98PieNlqJTmeU=",
+    "zh:01cfb11cb74654c003f6d4e32bbef8f5969ee2856394a96d127da4949c65153e",
+    "zh:0472ea1574026aa1e8ca82bb6df2c40cd0478e9336b7a8a64e652119a2fa4f32",
+    "zh:1a8ddba2b1550c5d02003ea5d6cdda2eef6870ece86c5619f33edd699c9dc14b",
+    "zh:1e3bb505c000adb12cdf60af5b08f0ed68bc3955b0d4d4a126db5ca4d429eb4a",
+    "zh:6636401b2463c25e03e68a6b786acf91a311c78444b1dc4f97c539f9f78de22a",
+    "zh:76858f9d8b460e7b2a338c477671d07286b0d287fd2d2e3214030ae8f61dd56e",
+    "zh:a13b69fb43cb8746793b3069c4d897bb18f454290b496f19d03c3387d1c9a2dc",
+    "zh:a90ca81bb9bb509063b736842250ecff0f886a91baae8de65c8430168001dad9",
+    "zh:c4de401395936e41234f1956ebadbd2ed9f414e6908f27d578614aaa529870d4",
+    "zh:c657e121af8fde19964482997f0de2d5173217274f6997e16389e7707ed8ece8",
+    "zh:d68b07a67fbd604c38ec9733069fbf23441436fecf554de6c75c032f82e1ef19",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infrastructure/team-dev/aws/au/cluster/cluster-nodes-apps.tf
+++ b/infrastructure/team-dev/aws/au/cluster/cluster-nodes-apps.tf
@@ -1,0 +1,30 @@
+module "app-nodes" {
+  source        = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
+  version       = "~> 20.8.5"
+  name          = "${local.envName}-app"
+  iam_role_name = "${local.envName}-app-node"
+  labels = {
+    "node.wescaleout.cloud/app" = "true"
+  }
+  taints = [
+    {
+      key    = "node.wescaleout.cloud/app"
+      value  = "true"
+      effect = "NO_SCHEDULE"
+    }
+  ]
+  cluster_name                      = module.eks.cluster_name
+  cluster_service_cidr              = module.eks.cluster_service_cidr
+  subnet_ids                        = local.network.vpc.private_subnets
+  cluster_primary_security_group_id = module.eks.cluster_primary_security_group_id
+  vpc_security_group_ids = [
+    module.eks.node_security_group_id
+  ]
+  instance_types           = ["t3.medium", "t3.small"]
+  capacity_type            = "SPOT"
+  min_size                 = 2
+  max_size                 = 6
+  desired_size             = 3
+  use_name_prefix          = false
+  iam_role_use_name_prefix = false
+}

--- a/infrastructure/team-dev/aws/au/cluster/cluster-nodes-apps.tf
+++ b/infrastructure/team-dev/aws/au/cluster/cluster-nodes-apps.tf
@@ -15,7 +15,7 @@ module "app-nodes" {
   ]
   cluster_name                      = module.eks.cluster_name
   cluster_service_cidr              = module.eks.cluster_service_cidr
-  subnet_ids                        = local.network.vpc.private_subnets
+  subnet_ids                        = local.network.private_subnets
   cluster_primary_security_group_id = module.eks.cluster_primary_security_group_id
   vpc_security_group_ids = [
     module.eks.node_security_group_id

--- a/infrastructure/team-dev/aws/au/cluster/cluster-nodes-routing.tf
+++ b/infrastructure/team-dev/aws/au/cluster/cluster-nodes-routing.tf
@@ -15,7 +15,7 @@ module "routing-nodes" {
   ]
   cluster_name                      = module.eks.cluster_name
   cluster_service_cidr              = module.eks.cluster_service_cidr
-  subnet_ids                        = local.network.vpc.private_subnets
+  subnet_ids                        = local.network.private_subnets
   cluster_primary_security_group_id = module.eks.cluster_primary_security_group_id
   vpc_security_group_ids = [
     module.eks.node_security_group_id,

--- a/infrastructure/team-dev/aws/au/cluster/cluster-nodes-routing.tf
+++ b/infrastructure/team-dev/aws/au/cluster/cluster-nodes-routing.tf
@@ -1,0 +1,31 @@
+module "routing-nodes" {
+  source        = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
+  version       = "~> 20.8.5"
+  name          = "${local.envName}-routing"
+  iam_role_name = "${local.envName}-routing-node"
+  labels = {
+    "node.wescaleout.cloud/routing" = "true"
+  }
+  taints = [
+    {
+      key    = "node.wescaleout.cloud/routing"
+      value  = "true"
+      effect = "NO_SCHEDULE"
+    }
+  ]
+  cluster_name                      = module.eks.cluster_name
+  cluster_service_cidr              = module.eks.cluster_service_cidr
+  subnet_ids                        = local.network.vpc.private_subnets
+  cluster_primary_security_group_id = module.eks.cluster_primary_security_group_id
+  vpc_security_group_ids = [
+    module.eks.node_security_group_id,
+    aws_security_group.lb-to-routing-nodes.id
+  ]
+  min_size                 = 2
+  max_size                 = 6
+  desired_size             = 3
+  instance_types           = ["t3.medium", "t3.small"]
+  capacity_type            = "SPOT"
+  use_name_prefix          = false
+  iam_role_use_name_prefix = false
+}

--- a/infrastructure/team-dev/aws/au/cluster/cluster-nodes-system.tf
+++ b/infrastructure/team-dev/aws/au/cluster/cluster-nodes-system.tf
@@ -1,0 +1,23 @@
+module "system-nodes" {
+  source        = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
+  version       = "~> 20.8.5"
+  name          = "${local.envName}-system"
+  iam_role_name = "${local.envName}-system-node"
+  labels = {
+    "node.wescaleout.cloud/system" = "true"
+  }
+  cluster_name                      = module.eks.cluster_name
+  cluster_service_cidr              = module.eks.cluster_service_cidr
+  subnet_ids                        = local.network.vpc.private_subnets
+  cluster_primary_security_group_id = module.eks.cluster_primary_security_group_id
+  vpc_security_group_ids = [
+    module.eks.node_security_group_id
+  ]
+  instance_types           = ["t3.medium", "t3.small"]
+  capacity_type            = "SPOT"
+  min_size                 = 2
+  max_size                 = 6
+  desired_size             = 3
+  use_name_prefix          = false
+  iam_role_use_name_prefix = false
+}

--- a/infrastructure/team-dev/aws/au/cluster/cluster-nodes-system.tf
+++ b/infrastructure/team-dev/aws/au/cluster/cluster-nodes-system.tf
@@ -8,7 +8,7 @@ module "system-nodes" {
   }
   cluster_name                      = module.eks.cluster_name
   cluster_service_cidr              = module.eks.cluster_service_cidr
-  subnet_ids                        = local.network.vpc.private_subnets
+  subnet_ids                        = local.network.private_subnets
   cluster_primary_security_group_id = module.eks.cluster_primary_security_group_id
   vpc_security_group_ids = [
     module.eks.node_security_group_id

--- a/infrastructure/team-dev/aws/au/cluster/cluster.tf
+++ b/infrastructure/team-dev/aws/au/cluster/cluster.tf
@@ -1,0 +1,16 @@
+module "eks" {
+  source                                   = "terraform-aws-modules/eks/aws"
+  version                                  = "~> 20.8.5"
+  cluster_name                             = local.envName
+  cluster_version                          = "1.29"
+  vpc_id                                   = local.network.vpc.vpc_id
+  subnet_ids                               = local.network.vpc.private_subnets
+  cluster_endpoint_public_access           = true
+  enable_cluster_creator_admin_permissions = true
+  cluster_addons = {
+    coredns    = {}
+    kube-proxy = {}
+    vpc-cni    = {}
+  }
+  tags = local.tags
+}

--- a/infrastructure/team-dev/aws/au/cluster/cluster.tf
+++ b/infrastructure/team-dev/aws/au/cluster/cluster.tf
@@ -3,8 +3,8 @@ module "eks" {
   version                                  = "~> 20.8.5"
   cluster_name                             = local.envName
   cluster_version                          = "1.29"
-  vpc_id                                   = local.network.vpc.vpc_id
-  subnet_ids                               = local.network.vpc.private_subnets
+  vpc_id                                   = local.network.vpc_id
+  subnet_ids                               = local.network.private_subnets
   cluster_endpoint_public_access           = true
   enable_cluster_creator_admin_permissions = true
   cluster_addons = {

--- a/infrastructure/team-dev/aws/au/cluster/config.tf
+++ b/infrastructure/team-dev/aws/au/cluster/config.tf
@@ -1,0 +1,35 @@
+data "aws_region" "this_env" {}
+data "aws_caller_identity" "this_env" {}
+
+locals {
+  provider  = "aws"
+  team      = "team"
+  env       = "dev"
+  region    = "au"
+  workspace = "cluster"
+  envName   = "${local.provider}-${local.team}-${local.env}-${local.region}"
+  name      = "${local.envName}-${local.workspace}"
+  tags      = {}
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "=5.45"
+    }
+  }
+  cloud {
+    organization = "scaleout"
+    workspaces {
+      project = "aws-team-dev-au"
+      name    = "aws-team-dev-au-cluster"
+    }
+  }
+}
+
+provider "aws" {
+  region  = "ap-southeast-2"
+  profile = "au"
+}
+

--- a/infrastructure/team-dev/aws/au/cluster/endpoint-sg-rules.tf
+++ b/infrastructure/team-dev/aws/au/cluster/endpoint-sg-rules.tf
@@ -11,7 +11,7 @@ resource "aws_security_group_rule" "private_subnets" {
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
-  cidr_blocks       = local.network.vpc.private_subnets_cidr_blocks
+  cidr_blocks       = local.network.private_subnets_cidr_blocks
   security_group_id = data.aws_security_group.vpc_endpoints.id
 }
 

--- a/infrastructure/team-dev/aws/au/cluster/endpoint-sg-rules.tf
+++ b/infrastructure/team-dev/aws/au/cluster/endpoint-sg-rules.tf
@@ -1,0 +1,34 @@
+# This security group is created for use with VPC endpoints, because our nodes are going to be the primary users
+# of the VPC endpoints we need to explicitly add rules for them to be able to communicate. This isn't posisble to
+# do during VPC creation because we have no yet made the EKS cluster.
+# Instead, we fetch the security group that is created for the endpoints and add one-off rules per what EKS requires.
+data "aws_security_group" "vpc_endpoints" {
+  name = "${local.envName}-network-vpc-interface-ingress"
+}
+
+resource "aws_security_group_rule" "private_subnets" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = local.network.vpc.private_subnets_cidr_blocks
+  security_group_id = data.aws_security_group.vpc_endpoints.id
+}
+
+resource "aws_security_group_rule" "eks_cluster_sg" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
+  source_security_group_id = module.eks.cluster_primary_security_group_id
+  security_group_id        = data.aws_security_group.vpc_endpoints.id
+}
+
+resource "aws_security_group_rule" "eks_nodes" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
+  source_security_group_id = module.eks.node_security_group_id
+  security_group_id        = data.aws_security_group.vpc_endpoints.id
+}

--- a/infrastructure/team-dev/aws/au/cluster/outputs.tf
+++ b/infrastructure/team-dev/aws/au/cluster/outputs.tf
@@ -1,0 +1,11 @@
+output "kubectl-bootstrap" {
+  value = "aws eks update-kubeconfig --name ${module.eks.cluster_name} --region ${data.aws_region.this_env.name} --profile ${local.region}"
+}
+
+output "routing_autoscaling_group_id" {
+  value = module.routing-nodes.node_group_autoscaling_group_names[0]
+}
+
+output "ingress_security_group_id" {
+  value = aws_security_group.lb-to-routing-nodes.id
+}

--- a/infrastructure/team-dev/aws/au/cluster/remote-states.tf
+++ b/infrastructure/team-dev/aws/au/cluster/remote-states.tf
@@ -1,0 +1,26 @@
+data "terraform_remote_state" "routing" {
+  backend = "remote"
+
+  config = {
+    organization = "scaleout"
+    workspaces = {
+      name = "scaleout-platform-routing"
+    }
+  }
+}
+
+data "terraform_remote_state" "network" {
+  backend = "remote"
+
+  config = {
+    organization = "scaleout"
+    workspaces = {
+      name = "aws-team-dev-au-network"
+    }
+  }
+}
+
+locals {
+  routing = data.terraform_remote_state.routing.outputs
+  network = data.terraform_remote_state.network.outputs
+}

--- a/infrastructure/team-dev/aws/au/cluster/security-groups.tf
+++ b/infrastructure/team-dev/aws/au/cluster/security-groups.tf
@@ -1,0 +1,8 @@
+resource "aws_security_group" "lb-to-routing-nodes" {
+  name        = "${local.envName}-lb-to-routing-nodes"
+  description = "Allow inbound traffic to routing nodes."
+  vpc_id      = local.network.vpc.vpc_id
+  tags = {
+    Name = "${local.envName}-lb-to-routing-nodes"
+  }
+}

--- a/infrastructure/team-dev/aws/au/cluster/security-groups.tf
+++ b/infrastructure/team-dev/aws/au/cluster/security-groups.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "lb-to-routing-nodes" {
   name        = "${local.envName}-lb-to-routing-nodes"
   description = "Allow inbound traffic to routing nodes."
-  vpc_id      = local.network.vpc.vpc_id
+  vpc_id      = local.network.vpc_id
   tags = {
     Name = "${local.envName}-lb-to-routing-nodes"
   }

--- a/infrastructure/team-dev/aws/au/network/.terraform.lock.hcl
+++ b/infrastructure/team-dev/aws/au/network/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.45.0"
+  constraints = "5.45.0"
+  hashes = [
+    "h1:4Vgk51R7iTY1oczaTQDG+DkA9nE8TmjlUtecqXX6qDU=",
+    "zh:1379bcf45aef3d486ee18b4f767bfecd40a0056510d26107f388be3d7994c368",
+    "zh:1615a6f5495acfb3a0cb72324587261dd4d72711a3cc51aff13167b14531501e",
+    "zh:18b69a0f33f8b1862fbd3f200756b7e83e087b73687085f2cf9c7da4c318e3e6",
+    "zh:2c5e7aecd197bc3d3b19290bad8cf4c390c2c6a77bb165da4e11f53f2dfe2e54",
+    "zh:3794da9bef97596e3bc60e12cdd915bda5ec2ed62cd1cd93723d58b4981905fe",
+    "zh:40a5e45ed91801f83db76dffd467dcf425ea2ca8642327cf01119601cb86021c",
+    "zh:4abfc3f53d0256a7d5d1fa5e931e4601b02db3d1da28f452341d3823d0518f1a",
+    "zh:4eb0e98078f79aeb06b5ff6115286dc2135d12a80287885698d04036425494a2",
+    "zh:75470efbadea4a8d783642497acaeec5077fc4a7f3df3340defeaa1c7de29bf7",
+    "zh:8861a0b4891d5fa2fa7142f236ae613cea966c45b5472e3915a4ac3abcbaf487",
+    "zh:8bf6f21cd9390b742ca0b4393fde92616ca9e6553fb75003a0999006ad233d35",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ad73008a044e75d337acda910fb54d8b81a366873c8a413fec1291034899a814",
+    "zh:bf261713b0b8bebfe8c199291365b87d9043849f28a2dc764bafdde73ae43693",
+    "zh:da3bafa1fd830be418dfcc730e85085fe67c0d415c066716f2ac350a2306f40a",
+  ]
+}

--- a/infrastructure/team-dev/aws/au/network/config.tf
+++ b/infrastructure/team-dev/aws/au/network/config.tf
@@ -9,6 +9,12 @@ locals {
   envName   = "${local.provider}-${local.team}-${local.env}-${local.region}"
   name      = "${local.envName}-${local.workspace}"
   tags      = {}
+  network = {
+    // https://www.davidc.net/sites/default/subnets/subnets.html?network=10.0.0.0&mask=20&division=13.3d40
+    cidr            = "10.0.0.0/20"
+    private_subnets = ["10.0.0.0/22", "10.0.4.0/22", "10.0.8.0/22"],
+    public_subnets  = ["10.0.12.0/24", "10.0.13.0/24", "10.0.14.0/24"]
+  }
 }
 
 terraform {

--- a/infrastructure/team-dev/aws/au/network/config.tf
+++ b/infrastructure/team-dev/aws/au/network/config.tf
@@ -1,0 +1,33 @@
+data "aws_region" "this_env" {}
+
+locals {
+  provider  = "aws"
+  team      = "team"
+  env       = "dev"
+  region    = "au"
+  workspace = "network"
+  envName   = "${local.provider}-${local.team}-${local.env}-${local.region}"
+  name      = "${local.envName}-${local.workspace}"
+  tags      = {}
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "=5.45"
+    }
+  }
+  cloud {
+    organization = "scaleout"
+    workspaces {
+      project = "aws-team-dev-au"
+      name    = "aws-team-dev-au-network"
+    }
+  }
+}
+
+provider "aws" {
+  region  = "ap-southeast-2"
+  profile = "au"
+}

--- a/infrastructure/team-dev/aws/au/network/endpoints.tf
+++ b/infrastructure/team-dev/aws/au/network/endpoints.tf
@@ -1,0 +1,44 @@
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = module.vpc.vpc_id
+  service_name      = "com.amazonaws.${data.aws_region.this_env.name}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids = concat(
+    module.vpc.public_route_table_ids,
+    module.vpc.private_route_table_ids,
+    module.vpc.database_route_table_ids
+  )
+}
+
+resource "aws_vpc_endpoint" "ecr_api" {
+  vpc_id            = module.vpc.vpc_id
+  service_name      = "com.amazonaws.${data.aws_region.this_env.name}.ecr.api"
+  vpc_endpoint_type = "Interface"
+  security_group_ids = [
+    aws_security_group.vpc_interface_ingress.id,
+  ]
+  subnet_ids          = module.vpc.private_subnets
+  private_dns_enabled = true
+}
+
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  vpc_id            = module.vpc.vpc_id
+  service_name      = "com.amazonaws.${data.aws_region.this_env.name}.ecr.dkr"
+  vpc_endpoint_type = "Interface"
+  security_group_ids = [
+    aws_security_group.vpc_interface_ingress.id,
+  ]
+  subnet_ids          = module.vpc.private_subnets
+  private_dns_enabled = true
+}
+
+resource "aws_security_group" "vpc_interface_ingress" {
+  vpc_id = module.vpc.vpc_id
+  name   = "${module.vpc.name}-vpc-interface-ingress"
+
+  tags = merge(local.tags, {
+    Name = "${module.vpc.name}-vpc-interface-ingress"
+  })
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}

--- a/infrastructure/team-dev/aws/au/network/outputs.tf
+++ b/infrastructure/team-dev/aws/au/network/outputs.tf
@@ -1,0 +1,3 @@
+output "vpc" {
+  value = module.vpc
+}

--- a/infrastructure/team-dev/aws/au/network/outputs.tf
+++ b/infrastructure/team-dev/aws/au/network/outputs.tf
@@ -1,3 +1,19 @@
-output "vpc" {
-  value = module.vpc
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "public_subnets" {
+  value = module.vpc.public_subnets
+}
+
+output "private_subnets" {
+  value = module.vpc.private_subnets
+}
+
+output "public_subnets_cidr_blocks" {
+  value = module.vpc.public_subnets_cidr_blocks
+}
+
+output "private_subnets_cidr_blocks" {
+  value = module.vpc.private_subnets_cidr_blocks
 }

--- a/infrastructure/team-dev/aws/au/network/vpc.tf
+++ b/infrastructure/team-dev/aws/au/network/vpc.tf
@@ -1,0 +1,50 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.7"
+
+  name = local.name
+  cidr = "10.0.0.0/20"
+
+  azs = ["${data.aws_region.this_env.name}a", "${data.aws_region.this_env.name}b", "${data.aws_region.this_env.name}c"]
+
+  # for slice up info see: https://www.davidc.net/sites/default/subnets/subnets.html?network=10.0.0.0&mask=20&division=25.3d9cc40
+  private_subnets  = ["10.0.0.0/22", "10.0.4.0/22", "10.0.8.0/22"]
+  database_subnets = ["10.0.12.0/25", "10.0.12.128/25", "10.0.13.0/25"]
+  # reserved for something in future: 10.0.13.128/25 10.0.14.0/25 10.0.14.128/25
+  public_subnets = ["10.0.15.0/26", "10.0.15.64/26", "10.0.15.128/26"] #10.0.15.192/26 left over
+
+  create_database_subnet_group = false
+
+  manage_default_network_acl = true
+  default_network_acl_tags   = { Name = "acl-${local.name}-default" }
+
+  manage_default_route_table = true
+  default_route_table_tags   = { Name = "rtb-${local.name}-default" }
+
+  manage_default_security_group = true
+  default_security_group_tags   = { Name = "sg-${local.name}-default" }
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  enable_nat_gateway     = true
+  single_nat_gateway     = false
+  one_nat_gateway_per_az = true
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = 1
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = 1
+  }
+
+  enable_vpn_gateway = false
+
+  enable_flow_log                      = true
+  create_flow_log_cloudwatch_log_group = true
+  create_flow_log_cloudwatch_iam_role  = true
+  flow_log_max_aggregation_interval    = 60
+
+  tags = local.tags
+}

--- a/infrastructure/team-dev/aws/au/network/vpc.tf
+++ b/infrastructure/team-dev/aws/au/network/vpc.tf
@@ -1,50 +1,37 @@
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 5.7"
-
-  name = local.name
-  cidr = "10.0.0.0/20"
-
-  azs = ["${data.aws_region.this_env.name}a", "${data.aws_region.this_env.name}b", "${data.aws_region.this_env.name}c"]
-
-  # for slice up info see: https://www.davidc.net/sites/default/subnets/subnets.html?network=10.0.0.0&mask=20&division=25.3d9cc40
-  private_subnets  = ["10.0.0.0/22", "10.0.4.0/22", "10.0.8.0/22"]
-  database_subnets = ["10.0.12.0/25", "10.0.12.128/25", "10.0.13.0/25"]
-  # reserved for something in future: 10.0.13.128/25 10.0.14.0/25 10.0.14.128/25
-  public_subnets = ["10.0.15.0/26", "10.0.15.64/26", "10.0.15.128/26"] #10.0.15.192/26 left over
-
-  create_database_subnet_group = false
-
-  manage_default_network_acl = true
-  default_network_acl_tags   = { Name = "acl-${local.name}-default" }
-
-  manage_default_route_table = true
-  default_route_table_tags   = { Name = "rtb-${local.name}-default" }
-
-  manage_default_security_group = true
-  default_security_group_tags   = { Name = "sg-${local.name}-default" }
-
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-
-  enable_nat_gateway     = true
-  single_nat_gateway     = false
-  one_nat_gateway_per_az = true
-
+  name    = local.name
+  azs = [
+    "${data.aws_region.this_env.name}a",
+    "${data.aws_region.this_env.name}b",
+    "${data.aws_region.this_env.name}c"
+  ]
+  cidr            = local.network.cidr
+  private_subnets = local.network.private_subnets
+  public_subnets  = local.network.public_subnets
   public_subnet_tags = {
     "kubernetes.io/role/elb" = 1
   }
-
   private_subnet_tags = {
     "kubernetes.io/role/internal-elb" = 1
   }
-
-  enable_vpn_gateway = false
-
+  create_database_subnet_group         = false
+  manage_default_network_acl           = true
+  default_network_acl_tags             = { Name = "${local.envName}-default" }
+  manage_default_route_table           = true
+  default_route_table_tags             = { Name = "${local.envName}-default" }
+  manage_default_security_group        = true
+  default_security_group_tags          = { Name = "${local.envName}-default" }
+  enable_dns_hostnames                 = true
+  enable_dns_support                   = true
+  enable_nat_gateway                   = true
+  single_nat_gateway                   = false
+  one_nat_gateway_per_az               = true
+  enable_vpn_gateway                   = false
   enable_flow_log                      = true
   create_flow_log_cloudwatch_log_group = true
   create_flow_log_cloudwatch_iam_role  = true
   flow_log_max_aggregation_interval    = 60
-
-  tags = local.tags
+  tags                                 = local.tags
 }

--- a/infrastructure/team-dev/aws/au/routing/.terraform.lock.hcl
+++ b/infrastructure/team-dev/aws/au/routing/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.45.0"
+  constraints = "5.45.0"
+  hashes = [
+    "h1:4Vgk51R7iTY1oczaTQDG+DkA9nE8TmjlUtecqXX6qDU=",
+    "zh:1379bcf45aef3d486ee18b4f767bfecd40a0056510d26107f388be3d7994c368",
+    "zh:1615a6f5495acfb3a0cb72324587261dd4d72711a3cc51aff13167b14531501e",
+    "zh:18b69a0f33f8b1862fbd3f200756b7e83e087b73687085f2cf9c7da4c318e3e6",
+    "zh:2c5e7aecd197bc3d3b19290bad8cf4c390c2c6a77bb165da4e11f53f2dfe2e54",
+    "zh:3794da9bef97596e3bc60e12cdd915bda5ec2ed62cd1cd93723d58b4981905fe",
+    "zh:40a5e45ed91801f83db76dffd467dcf425ea2ca8642327cf01119601cb86021c",
+    "zh:4abfc3f53d0256a7d5d1fa5e931e4601b02db3d1da28f452341d3823d0518f1a",
+    "zh:4eb0e98078f79aeb06b5ff6115286dc2135d12a80287885698d04036425494a2",
+    "zh:75470efbadea4a8d783642497acaeec5077fc4a7f3df3340defeaa1c7de29bf7",
+    "zh:8861a0b4891d5fa2fa7142f236ae613cea966c45b5472e3915a4ac3abcbaf487",
+    "zh:8bf6f21cd9390b742ca0b4393fde92616ca9e6553fb75003a0999006ad233d35",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ad73008a044e75d337acda910fb54d8b81a366873c8a413fec1291034899a814",
+    "zh:bf261713b0b8bebfe8c199291365b87d9043849f28a2dc764bafdde73ae43693",
+    "zh:da3bafa1fd830be418dfcc730e85085fe67c0d415c066716f2ac350a2306f40a",
+  ]
+}

--- a/infrastructure/team-dev/aws/au/routing/config.tf
+++ b/infrastructure/team-dev/aws/au/routing/config.tf
@@ -1,0 +1,31 @@
+locals {
+  provider  = "aws"
+  team      = "team"
+  env       = "dev"
+  region    = "au"
+  workspace = "routing"
+  envName   = "${local.provider}-${local.team}-${local.env}-${local.region}"
+  name      = "${local.envName}-${local.workspace}"
+  tags      = {}
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "=5.45"
+    }
+  }
+  cloud {
+    organization = "scaleout"
+    workspaces {
+      project = "aws-team-dev-au"
+      name    = "aws-team-dev-au-routing"
+    }
+  }
+}
+
+provider "aws" {
+  region  = "ap-southeast-2"
+  profile = "au"
+}

--- a/infrastructure/team-dev/aws/au/routing/dns-public.tf
+++ b/infrastructure/team-dev/aws/au/routing/dns-public.tf
@@ -1,0 +1,21 @@
+resource "aws_route53_record" "public_apex" {
+  zone_id = local.routing.zone_id
+  name    = local.routing.domain
+  type    = "A"
+  alias {
+    name                   = aws_lb.public_ingress.dns_name
+    zone_id                = aws_lb.public_ingress.zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "public_star" {
+  zone_id = local.routing.zone_id
+  name    = "*.${local.routing.domain}"
+  type    = "A"
+  alias {
+    name                   = aws_lb.public_ingress.dns_name
+    zone_id                = aws_lb.public_ingress.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/infrastructure/team-dev/aws/au/routing/hack/nginx.yml
+++ b/infrastructure/team-dev/aws/au/routing/hack/nginx.yml
@@ -3,10 +3,18 @@ kind: Namespace
 metadata:
   name: routing
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-html
+  namespace: routing
+data:
+  index.html: aws-au
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-deployment
+  name: nginx
   namespace: routing
 spec:
   selector:
@@ -18,11 +26,18 @@ spec:
       labels:
         app: nginx
     spec:
+      volumes:
+      - name: nginx-html
+        configMap:
+          name: nginx-html
       containers:
       - name: nginx
         image: nginx:1.25.4
         ports:
         - containerPort: 80
+        volumeMounts:
+        - mountPath: /usr/share/nginx/html
+          name: nginx-html
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/infrastructure/team-dev/aws/au/routing/hack/nginx.yml
+++ b/infrastructure/team-dev/aws/au/routing/hack/nginx.yml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: routing
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: routing
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.25.4
+        ports:
+        - containerPort: 80
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - nginx
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+      nodeSelector:
+        node.wescaleout.cloud/routing: "true"
+      tolerations:
+      - key: node.wescaleout.cloud/routing
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx
+  namespace: routing
+spec:
+  type: NodePort
+  selector:
+    app: nginx
+  ports:
+    - name: health
+      protocol: "TCP"
+      port: 30877
+      nodePort: 30877
+      targetPort: 80
+    - name: http
+      protocol: "TCP"
+      port: 31080
+      nodePort: 31080
+      targetPort: 80

--- a/infrastructure/team-dev/aws/au/routing/ingress-public.tf
+++ b/infrastructure/team-dev/aws/au/routing/ingress-public.tf
@@ -1,0 +1,136 @@
+resource "aws_lb" "public_ingress" {
+  name         = "lb-${local.name}"
+  subnets      = local.network.vpc.public_subnets
+  idle_timeout = 130
+  security_groups = [
+    aws_security_group.public_ingress.id
+  ]
+  tags = merge(local.tags, {
+    Name = "lb-${local.name}"
+  })
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "aws_lb_target_group" "public_ingress" {
+  name     = "${local.name}-ingress"
+  port     = 31080
+  protocol = "HTTP"
+  vpc_id   = local.network.vpc.vpc_id
+  stickiness {
+    type    = "lb_cookie"
+    enabled = false
+  }
+  /*
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+    protocol            = "HTTP"
+    port                = 30877
+    path                = "/"
+    interval            = 60
+  }
+  */
+}
+
+data "aws_eks_node_group" "routing" {
+  cluster_name    = local.envName
+  node_group_name = "${local.envName}-routing"
+}
+
+resource "aws_autoscaling_attachment" "public_ingress" {
+  lb_target_group_arn    = aws_lb_target_group.public_ingress.arn
+  autoscaling_group_name = data.aws_eks_node_group.routing.resources[0].autoscaling_groups[0].name
+}
+
+resource "aws_lb_listener" "public_ingress_nonsecure" {
+  load_balancer_arn = aws_lb.public_ingress.arn
+  port              = 80
+  protocol          = "HTTP"
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+resource "aws_lb_listener" "public_ingress" {
+  load_balancer_arn = aws_lb.public_ingress.arn
+  port              = 443
+  protocol          = "HTTPS"
+  certificate_arn   = local.routing.certificate_arn
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.public_ingress.arn
+  }
+}
+
+// hide endpoints
+resource "aws_lb_listener_rule" "public_ingress_prevent_public" {
+  for_each = {
+    metrics = {
+      status_code  = 404
+      message_body = "Not Found"
+    },
+    health = {
+      status_code  = 404
+      message_body = "Not Found"
+    },
+    liveness = {
+      status_code  = 404
+      message_body = "Not Found"
+    }
+    readiness = {
+      status_code  = 404
+      message_body = "Not Found"
+    }
+  }
+  listener_arn = aws_lb_listener.public_ingress.arn
+  action {
+    type = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = each.value.message_body
+      status_code  = each.value.status_code
+    }
+  }
+  condition {
+    path_pattern {
+      values = [format("/%s", each.key)]
+    }
+  }
+}
+
+resource "aws_security_group" "public_ingress" {
+  name   = "${local.name}-world-to-lb"
+  vpc_id = local.network.vpc.vpc_id
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = merge(local.tags, {
+    Name = "${local.name}-world-to-lb"
+  })
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}

--- a/infrastructure/team-dev/aws/au/routing/ingress-public.tf
+++ b/infrastructure/team-dev/aws/au/routing/ingress-public.tf
@@ -1,6 +1,6 @@
 resource "aws_lb" "public_ingress" {
   name         = local.name
-  subnets      = local.network.vpc.public_subnets
+  subnets      = local.network.public_subnets
   idle_timeout = 130
   security_groups = [
     aws_security_group.public_ingress.id
@@ -17,7 +17,7 @@ resource "aws_lb_target_group" "public_ingress" {
   name     = "${local.name}-ingress"
   port     = 31080
   protocol = "HTTP"
-  vpc_id   = local.network.vpc.vpc_id
+  vpc_id   = local.network.vpc_id
   stickiness {
     type    = "lb_cookie"
     enabled = false
@@ -108,7 +108,7 @@ resource "aws_lb_listener_rule" "public_ingress_prevent_public" {
 
 resource "aws_security_group" "public_ingress" {
   name   = "${local.name}-world-to-lb"
-  vpc_id = local.network.vpc.vpc_id
+  vpc_id = local.network.vpc_id
   egress {
     from_port   = 0
     to_port     = 0

--- a/infrastructure/team-dev/aws/au/routing/ingress-public.tf
+++ b/infrastructure/team-dev/aws/au/routing/ingress-public.tf
@@ -1,12 +1,12 @@
 resource "aws_lb" "public_ingress" {
-  name         = "lb-${local.name}"
+  name         = local.name
   subnets      = local.network.vpc.public_subnets
   idle_timeout = 130
   security_groups = [
     aws_security_group.public_ingress.id
   ]
   tags = merge(local.tags, {
-    Name = "lb-${local.name}"
+    Name = local.name
   })
   lifecycle {
     ignore_changes = [tags]

--- a/infrastructure/team-dev/aws/au/routing/ingress-public.tf
+++ b/infrastructure/team-dev/aws/au/routing/ingress-public.tf
@@ -22,7 +22,6 @@ resource "aws_lb_target_group" "public_ingress" {
     type    = "lb_cookie"
     enabled = false
   }
-  /*
   health_check {
     healthy_threshold   = 2
     unhealthy_threshold = 2
@@ -32,7 +31,6 @@ resource "aws_lb_target_group" "public_ingress" {
     path                = "/"
     interval            = 60
   }
-  */
 }
 
 data "aws_eks_node_group" "routing" {

--- a/infrastructure/team-dev/aws/au/routing/remote-states.tf
+++ b/infrastructure/team-dev/aws/au/routing/remote-states.tf
@@ -1,0 +1,38 @@
+data "terraform_remote_state" "routing" {
+  backend = "remote"
+
+  config = {
+    organization = "scaleout"
+    workspaces = {
+      name = "scaleout-platform-team-dev-routing"
+    }
+  }
+}
+
+data "terraform_remote_state" "network" {
+  backend = "remote"
+
+  config = {
+    organization = "scaleout"
+    workspaces = {
+      name = "aws-team-dev-au-network"
+    }
+  }
+}
+
+data "terraform_remote_state" "cluster" {
+  backend = "remote"
+
+  config = {
+    organization = "scaleout"
+    workspaces = {
+      name = "aws-team-dev-au-cluster"
+    }
+  }
+}
+
+locals {
+  routing = data.terraform_remote_state.routing.outputs.aws-au
+  network = data.terraform_remote_state.network.outputs
+  cluster = data.terraform_remote_state.cluster.outputs
+}

--- a/infrastructure/team-dev/aws/au/routing/security-groups.tf
+++ b/infrastructure/team-dev/aws/au/routing/security-groups.tf
@@ -1,0 +1,17 @@
+resource "aws_security_group_rule" "eks_cluster_lb_ingress" {
+  type                     = "ingress"
+  from_port                = 31080
+  to_port                  = 31080
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.public_ingress.id
+  security_group_id        = local.cluster.ingress_security_group_id
+}
+
+resource "aws_security_group_rule" "eks_cluster_lb_health_ingress" {
+  type                     = "ingress"
+  from_port                = 30877
+  to_port                  = 30877
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.public_ingress.id
+  security_group_id        = local.cluster.ingress_security_group_id
+}

--- a/infrastructure/team-dev/aws/us/cluster-config/.terraform.lock.hcl
+++ b/infrastructure/team-dev/aws/us/cluster-config/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/gavinbunney/kubectl" {
+  version     = "1.14.0"
+  constraints = "1.14.0"
+  hashes = [
+    "h1:gLFn+RvP37sVzp9qnFCwngRjjFV649r6apjxvJ1E/SE=",
+    "zh:0350f3122ff711984bbc36f6093c1fe19043173fad5a904bce27f86afe3cc858",
+    "zh:07ca36c7aa7533e8325b38232c77c04d6ef1081cb0bac9d56e8ccd51f12f2030",
+    "zh:0c351afd91d9e994a71fe64bbd1662d0024006b3493bb61d46c23ea3e42a7cf5",
+    "zh:39f1a0aa1d589a7e815b62b5aa11041040903b061672c4cfc7de38622866cbc4",
+    "zh:428d3a321043b78e23c91a8d641f2d08d6b97f74c195c654f04d2c455e017de5",
+    "zh:4baf5b1de2dfe9968cc0f57fd4be5a741deb5b34ee0989519267697af5f3eee5",
+    "zh:6131a927f9dffa014ab5ca5364ac965fe9b19830d2bbf916a5b2865b956fdfcf",
+    "zh:c62e0c9fd052cbf68c5c2612af4f6408c61c7e37b615dc347918d2442dd05e93",
+    "zh:f0beffd7ce78f49ead612e4b1aefb7cb6a461d040428f514f4f9cc4e5698ac65",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.45.0"
+  constraints = "5.45.0"
+  hashes = [
+    "h1:4Vgk51R7iTY1oczaTQDG+DkA9nE8TmjlUtecqXX6qDU=",
+    "zh:1379bcf45aef3d486ee18b4f767bfecd40a0056510d26107f388be3d7994c368",
+    "zh:1615a6f5495acfb3a0cb72324587261dd4d72711a3cc51aff13167b14531501e",
+    "zh:18b69a0f33f8b1862fbd3f200756b7e83e087b73687085f2cf9c7da4c318e3e6",
+    "zh:2c5e7aecd197bc3d3b19290bad8cf4c390c2c6a77bb165da4e11f53f2dfe2e54",
+    "zh:3794da9bef97596e3bc60e12cdd915bda5ec2ed62cd1cd93723d58b4981905fe",
+    "zh:40a5e45ed91801f83db76dffd467dcf425ea2ca8642327cf01119601cb86021c",
+    "zh:4abfc3f53d0256a7d5d1fa5e931e4601b02db3d1da28f452341d3823d0518f1a",
+    "zh:4eb0e98078f79aeb06b5ff6115286dc2135d12a80287885698d04036425494a2",
+    "zh:75470efbadea4a8d783642497acaeec5077fc4a7f3df3340defeaa1c7de29bf7",
+    "zh:8861a0b4891d5fa2fa7142f236ae613cea966c45b5472e3915a4ac3abcbaf487",
+    "zh:8bf6f21cd9390b742ca0b4393fde92616ca9e6553fb75003a0999006ad233d35",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ad73008a044e75d337acda910fb54d8b81a366873c8a413fec1291034899a814",
+    "zh:bf261713b0b8bebfe8c199291365b87d9043849f28a2dc764bafdde73ae43693",
+    "zh:da3bafa1fd830be418dfcc730e85085fe67c0d415c066716f2ac350a2306f40a",
+  ]
+}

--- a/infrastructure/team-dev/aws/us/cluster-config/config.tf
+++ b/infrastructure/team-dev/aws/us/cluster-config/config.tf
@@ -1,0 +1,48 @@
+data "aws_eks_cluster" "this_env" {
+  name = local.envName
+}
+
+data "aws_eks_cluster_auth" "this_env" {
+  name = local.envName
+}
+
+locals {
+  provider  = "aws"
+  team      = "team"
+  env       = "dev"
+  region    = "au"
+  workspace = "cluster-config"
+  envName   = "${local.provider}-${local.team}-${local.env}-${local.region}"
+  name      = "${local.envName}-${local.workspace}"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "=5.45"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "=1.14.0"
+    }
+  }
+  cloud {
+    organization = "scaleout"
+    workspaces {
+      project = "aws-team-dev-au"
+      name    = "aws-team-dev-au-cluster-config"
+    }
+  }
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  profile = "us"
+}
+
+provider "kubectl" {
+  host                   = data.aws_eks_cluster.this_env.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this_env.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.this_env.token
+}

--- a/infrastructure/team-dev/aws/us/cluster-config/config.tf
+++ b/infrastructure/team-dev/aws/us/cluster-config/config.tf
@@ -10,7 +10,7 @@ locals {
   provider  = "aws"
   team      = "team"
   env       = "dev"
-  region    = "au"
+  region    = "us"
   workspace = "cluster-config"
   envName   = "${local.provider}-${local.team}-${local.env}-${local.region}"
   name      = "${local.envName}-${local.workspace}"
@@ -30,8 +30,8 @@ terraform {
   cloud {
     organization = "scaleout"
     workspaces {
-      project = "aws-team-dev-au"
-      name    = "aws-team-dev-au-cluster-config"
+      project = "aws-team-dev-us"
+      name    = "aws-team-dev-us-cluster-config"
     }
   }
 }

--- a/infrastructure/team-dev/aws/us/cluster-config/install.tf
+++ b/infrastructure/team-dev/aws/us/cluster-config/install.tf
@@ -1,0 +1,4 @@
+resource "kubectl_manifest" "ingress" {
+  for_each  = toset(split("---", file("${path.module}/nginx.yml")))
+  yaml_body = each.value
+}

--- a/infrastructure/team-dev/aws/us/cluster-config/nginx.yml
+++ b/infrastructure/team-dev/aws/us/cluster-config/nginx.yml
@@ -9,7 +9,7 @@ metadata:
   name: nginx-html
   namespace: routing
 data:
-  index.html: aws-au
+  index.html: hello from aws-us!
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -38,16 +38,13 @@ spec:
         volumeMounts:
         - mountPath: /usr/share/nginx/html
           name: nginx-html
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - nginx
-            topologyKey: failure-domain.beta.kubernetes.io/zone
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: nginx
       nodeSelector:
         node.wescaleout.cloud/routing: "true"
       tolerations:

--- a/infrastructure/team-dev/aws/us/cluster/.terraform.lock.hcl
+++ b/infrastructure/team-dev/aws/us/cluster/.terraform.lock.hcl
@@ -1,0 +1,105 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.45.0"
+  constraints = ">= 4.33.0, >= 5.40.0, 5.45.0"
+  hashes = [
+    "h1:4Vgk51R7iTY1oczaTQDG+DkA9nE8TmjlUtecqXX6qDU=",
+    "zh:1379bcf45aef3d486ee18b4f767bfecd40a0056510d26107f388be3d7994c368",
+    "zh:1615a6f5495acfb3a0cb72324587261dd4d72711a3cc51aff13167b14531501e",
+    "zh:18b69a0f33f8b1862fbd3f200756b7e83e087b73687085f2cf9c7da4c318e3e6",
+    "zh:2c5e7aecd197bc3d3b19290bad8cf4c390c2c6a77bb165da4e11f53f2dfe2e54",
+    "zh:3794da9bef97596e3bc60e12cdd915bda5ec2ed62cd1cd93723d58b4981905fe",
+    "zh:40a5e45ed91801f83db76dffd467dcf425ea2ca8642327cf01119601cb86021c",
+    "zh:4abfc3f53d0256a7d5d1fa5e931e4601b02db3d1da28f452341d3823d0518f1a",
+    "zh:4eb0e98078f79aeb06b5ff6115286dc2135d12a80287885698d04036425494a2",
+    "zh:75470efbadea4a8d783642497acaeec5077fc4a7f3df3340defeaa1c7de29bf7",
+    "zh:8861a0b4891d5fa2fa7142f236ae613cea966c45b5472e3915a4ac3abcbaf487",
+    "zh:8bf6f21cd9390b742ca0b4393fde92616ca9e6553fb75003a0999006ad233d35",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ad73008a044e75d337acda910fb54d8b81a366873c8a413fec1291034899a814",
+    "zh:bf261713b0b8bebfe8c199291365b87d9043849f28a2dc764bafdde73ae43693",
+    "zh:da3bafa1fd830be418dfcc730e85085fe67c0d415c066716f2ac350a2306f40a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version     = "2.3.3"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:U6EC4/cJJ6Df3LztUQ/I4YuljGQQeQ+LdLndAwSSiTs=",
+    "zh:0bd6ee14ca5cf0f0c83d3bb965346b1225ccd06a6247e80774aaaf54c729daa7",
+    "zh:3055ad0dcc98de1d4e45b72c5889ae91b62f4ae4e54dbc56c4821be0fdfbed91",
+    "zh:32764cfcff0d7379ca8b7dde376ac5551854d454c5881945f1952b785a312fa2",
+    "zh:55c2a4dc3ebdeaa1dec3a36db96dab253c7fa10b9fe1209862e1ee77a01e0aa1",
+    "zh:5c71f260ba5674d656d12f67cde3bb494498e6b6b6e66945ef85688f185dcf63",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9617280a853ec7caedb8beb7864e4b29faf9c850a453283980c28fccef2c493d",
+    "zh:ac8bda21950f8dddade3e9bc15f7bcfdee743738483be5724169943cafa611f5",
+    "zh:ba9ab567bbe63dee9197a763b3104ea9217ba27449ed54d3afa6657f412e3496",
+    "zh:effd1a7e34bae3879c02f03ed3afa979433a518e11de1f8afd35a8710231ac14",
+    "zh:f021538c86d0ac250d75e59efde6d869bbfff711eb744c8bddce79d2475bf46d",
+    "zh:f1e3984597948a2103391a26600e177b19f16a5a4c66acee27a4343fb141571f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.2"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
+    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
+    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
+    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
+    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
+    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
+    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
+    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
+    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
+    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
+    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.11.1"
+  constraints = ">= 0.9.0"
+  hashes = [
+    "h1:IkDriv5C9G+kQQ+mP+8QGIahwKgbQcw1/mzh9U6q+ZI=",
+    "zh:19a393db736ec4fd024d098d55aefaef07056c37a448ece3b55b3f5f4c2c7e4a",
+    "zh:227fa1e221de2907f37be78d40c06ca6a6f7b243a1ec33ade014dfaf6d92cd9c",
+    "zh:29970fecbf4a3ca23bacbb05d6b90cdd33dd379f90059fe39e08289951502d9f",
+    "zh:65024596f22f10e7dcb5e0e4a75277f275b529daa0bc0daf34ca7901c678ab88",
+    "zh:694d080cb5e3bf5ef08c7409208d061c135a4f5f4cdc93ea8607860995264b2e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b29d15d13e1b3412e6a4e1627d378dbd102659132f7488f64017dd6b6d5216d3",
+    "zh:bb79f4cae9f8c17c73998edc54aa16c2130a03227f7f4e71fc6ac87e230575ec",
+    "zh:ceccf80e95929d97f62dcf1bb3c7c7553d5757b2d9e7d222518722fc934f7ad5",
+    "zh:f40e638336527490e294d9c938ae55919069e6987e85a80506784ba90348792a",
+    "zh:f99ef33b1629a3b2278201142a3011a8489e66d92da832a5b99e442204de18fb",
+    "zh:fded14754ea46fdecc62a52cd970126420d4cd190e598cb61190b4724a727edb",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.0.5"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:e4LBdJoZJNOQXPWgOAG0UuPBVhCStu98PieNlqJTmeU=",
+    "zh:01cfb11cb74654c003f6d4e32bbef8f5969ee2856394a96d127da4949c65153e",
+    "zh:0472ea1574026aa1e8ca82bb6df2c40cd0478e9336b7a8a64e652119a2fa4f32",
+    "zh:1a8ddba2b1550c5d02003ea5d6cdda2eef6870ece86c5619f33edd699c9dc14b",
+    "zh:1e3bb505c000adb12cdf60af5b08f0ed68bc3955b0d4d4a126db5ca4d429eb4a",
+    "zh:6636401b2463c25e03e68a6b786acf91a311c78444b1dc4f97c539f9f78de22a",
+    "zh:76858f9d8b460e7b2a338c477671d07286b0d287fd2d2e3214030ae8f61dd56e",
+    "zh:a13b69fb43cb8746793b3069c4d897bb18f454290b496f19d03c3387d1c9a2dc",
+    "zh:a90ca81bb9bb509063b736842250ecff0f886a91baae8de65c8430168001dad9",
+    "zh:c4de401395936e41234f1956ebadbd2ed9f414e6908f27d578614aaa529870d4",
+    "zh:c657e121af8fde19964482997f0de2d5173217274f6997e16389e7707ed8ece8",
+    "zh:d68b07a67fbd604c38ec9733069fbf23441436fecf554de6c75c032f82e1ef19",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infrastructure/team-dev/aws/us/cluster/cluster-nodes-apps.tf
+++ b/infrastructure/team-dev/aws/us/cluster/cluster-nodes-apps.tf
@@ -1,0 +1,30 @@
+module "app-nodes" {
+  source        = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
+  version       = "~> 20.8.5"
+  name          = "${local.envName}-app"
+  iam_role_name = "${local.envName}-app-node"
+  labels = {
+    "node.wescaleout.cloud/app" = "true"
+  }
+  taints = [
+    {
+      key    = "node.wescaleout.cloud/app"
+      value  = "true"
+      effect = "NO_SCHEDULE"
+    }
+  ]
+  cluster_name                      = module.eks.cluster_name
+  cluster_service_cidr              = module.eks.cluster_service_cidr
+  subnet_ids                        = local.network.vpc.private_subnets
+  cluster_primary_security_group_id = module.eks.cluster_primary_security_group_id
+  vpc_security_group_ids = [
+    module.eks.node_security_group_id
+  ]
+  instance_types           = ["t3.medium", "t3.small"]
+  capacity_type            = "SPOT"
+  min_size                 = 2
+  max_size                 = 6
+  desired_size             = 3
+  use_name_prefix          = false
+  iam_role_use_name_prefix = false
+}

--- a/infrastructure/team-dev/aws/us/cluster/cluster-nodes-apps.tf
+++ b/infrastructure/team-dev/aws/us/cluster/cluster-nodes-apps.tf
@@ -15,7 +15,7 @@ module "app-nodes" {
   ]
   cluster_name                      = module.eks.cluster_name
   cluster_service_cidr              = module.eks.cluster_service_cidr
-  subnet_ids                        = local.network.vpc.private_subnets
+  subnet_ids                        = local.network.private_subnets
   cluster_primary_security_group_id = module.eks.cluster_primary_security_group_id
   vpc_security_group_ids = [
     module.eks.node_security_group_id

--- a/infrastructure/team-dev/aws/us/cluster/cluster-nodes-routing.tf
+++ b/infrastructure/team-dev/aws/us/cluster/cluster-nodes-routing.tf
@@ -15,7 +15,7 @@ module "routing-nodes" {
   ]
   cluster_name                      = module.eks.cluster_name
   cluster_service_cidr              = module.eks.cluster_service_cidr
-  subnet_ids                        = local.network.vpc.private_subnets
+  subnet_ids                        = local.network.private_subnets
   cluster_primary_security_group_id = module.eks.cluster_primary_security_group_id
   vpc_security_group_ids = [
     module.eks.node_security_group_id,

--- a/infrastructure/team-dev/aws/us/cluster/cluster-nodes-routing.tf
+++ b/infrastructure/team-dev/aws/us/cluster/cluster-nodes-routing.tf
@@ -1,0 +1,31 @@
+module "routing-nodes" {
+  source        = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
+  version       = "~> 20.8.5"
+  name          = "${local.envName}-routing"
+  iam_role_name = "${local.envName}-routing-node"
+  labels = {
+    "node.wescaleout.cloud/routing" = "true"
+  }
+  taints = [
+    {
+      key    = "node.wescaleout.cloud/routing"
+      value  = "true"
+      effect = "NO_SCHEDULE"
+    }
+  ]
+  cluster_name                      = module.eks.cluster_name
+  cluster_service_cidr              = module.eks.cluster_service_cidr
+  subnet_ids                        = local.network.vpc.private_subnets
+  cluster_primary_security_group_id = module.eks.cluster_primary_security_group_id
+  vpc_security_group_ids = [
+    module.eks.node_security_group_id,
+    aws_security_group.lb-to-routing-nodes.id
+  ]
+  min_size                 = 2
+  max_size                 = 6
+  desired_size             = 3
+  instance_types           = ["t3.medium", "t3.small"]
+  capacity_type            = "SPOT"
+  use_name_prefix          = false
+  iam_role_use_name_prefix = false
+}

--- a/infrastructure/team-dev/aws/us/cluster/cluster-nodes-system.tf
+++ b/infrastructure/team-dev/aws/us/cluster/cluster-nodes-system.tf
@@ -1,0 +1,23 @@
+module "system-nodes" {
+  source        = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
+  version       = "~> 20.8.5"
+  name          = "${local.envName}-system"
+  iam_role_name = "${local.envName}-system-node"
+  labels = {
+    "node.wescaleout.cloud/system" = "true"
+  }
+  cluster_name                      = module.eks.cluster_name
+  cluster_service_cidr              = module.eks.cluster_service_cidr
+  subnet_ids                        = local.network.vpc.private_subnets
+  cluster_primary_security_group_id = module.eks.cluster_primary_security_group_id
+  vpc_security_group_ids = [
+    module.eks.node_security_group_id
+  ]
+  instance_types           = ["t3.medium", "t3.small"]
+  capacity_type            = "SPOT"
+  min_size                 = 2
+  max_size                 = 6
+  desired_size             = 3
+  use_name_prefix          = false
+  iam_role_use_name_prefix = false
+}

--- a/infrastructure/team-dev/aws/us/cluster/cluster-nodes-system.tf
+++ b/infrastructure/team-dev/aws/us/cluster/cluster-nodes-system.tf
@@ -8,7 +8,7 @@ module "system-nodes" {
   }
   cluster_name                      = module.eks.cluster_name
   cluster_service_cidr              = module.eks.cluster_service_cidr
-  subnet_ids                        = local.network.vpc.private_subnets
+  subnet_ids                        = local.network.private_subnets
   cluster_primary_security_group_id = module.eks.cluster_primary_security_group_id
   vpc_security_group_ids = [
     module.eks.node_security_group_id

--- a/infrastructure/team-dev/aws/us/cluster/cluster.tf
+++ b/infrastructure/team-dev/aws/us/cluster/cluster.tf
@@ -3,8 +3,8 @@ module "eks" {
   version                                  = "~> 20.8.5"
   cluster_name                             = local.envName
   cluster_version                          = "1.29"
-  vpc_id                                   = local.network.vpc.vpc_id
-  subnet_ids                               = local.network.vpc.private_subnets
+  vpc_id                                   = local.network.vpc_id
+  subnet_ids                               = local.network.private_subnets
   cluster_endpoint_public_access           = true
   enable_cluster_creator_admin_permissions = true
   cluster_addons = {

--- a/infrastructure/team-dev/aws/us/cluster/cluster.tf
+++ b/infrastructure/team-dev/aws/us/cluster/cluster.tf
@@ -1,0 +1,22 @@
+module "eks" {
+  source                                   = "terraform-aws-modules/eks/aws"
+  version                                  = "~> 20.8.5"
+  cluster_name                             = local.envName
+  cluster_version                          = "1.29"
+  vpc_id                                   = local.network.vpc.vpc_id
+  subnet_ids                               = local.network.vpc.private_subnets
+  cluster_endpoint_public_access           = true
+  enable_cluster_creator_admin_permissions = true
+  cluster_addons = {
+    coredns = {
+      most_recent = true
+    }
+    kube-proxy = {
+      most_recent = true
+    }
+    vpc-cni = {
+      most_recent = true
+    }
+  }
+  tags = local.tags
+}

--- a/infrastructure/team-dev/aws/us/cluster/config.tf
+++ b/infrastructure/team-dev/aws/us/cluster/config.tf
@@ -1,0 +1,35 @@
+data "aws_region" "this_env" {}
+data "aws_caller_identity" "this_env" {}
+
+locals {
+  provider  = "aws"
+  team      = "team"
+  env       = "dev"
+  region    = "us"
+  workspace = "cluster"
+  envName   = "${local.provider}-${local.team}-${local.env}-${local.region}"
+  name      = "${local.envName}-${local.workspace}"
+  tags      = {}
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "=5.45"
+    }
+  }
+  cloud {
+    organization = "scaleout"
+    workspaces {
+      project = "aws-team-dev-us"
+      name    = "aws-team-dev-us-cluster"
+    }
+  }
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  profile = "us"
+}
+

--- a/infrastructure/team-dev/aws/us/cluster/endpoint-sg-rules.tf
+++ b/infrastructure/team-dev/aws/us/cluster/endpoint-sg-rules.tf
@@ -11,7 +11,7 @@ resource "aws_security_group_rule" "private_subnets" {
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
-  cidr_blocks       = local.network.vpc.private_subnets_cidr_blocks
+  cidr_blocks       = local.network.private_subnets_cidr_blocks
   security_group_id = data.aws_security_group.vpc_endpoints.id
 }
 

--- a/infrastructure/team-dev/aws/us/cluster/endpoint-sg-rules.tf
+++ b/infrastructure/team-dev/aws/us/cluster/endpoint-sg-rules.tf
@@ -1,0 +1,34 @@
+# This security group is created for use with VPC endpoints, because our nodes are going to be the primary users
+# of the VPC endpoints we need to explicitly add rules for them to be able to communicate. This isn't posisble to
+# do during VPC creation because we have no yet made the EKS cluster.
+# Instead, we fetch the security group that is created for the endpoints and add one-off rules per what EKS requires.
+data "aws_security_group" "vpc_endpoints" {
+  name = "${local.envName}-network-vpc-interface-ingress"
+}
+
+resource "aws_security_group_rule" "private_subnets" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = local.network.vpc.private_subnets_cidr_blocks
+  security_group_id = data.aws_security_group.vpc_endpoints.id
+}
+
+resource "aws_security_group_rule" "eks_cluster_sg" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
+  source_security_group_id = module.eks.cluster_primary_security_group_id
+  security_group_id        = data.aws_security_group.vpc_endpoints.id
+}
+
+resource "aws_security_group_rule" "eks_nodes" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
+  source_security_group_id = module.eks.node_security_group_id
+  security_group_id        = data.aws_security_group.vpc_endpoints.id
+}

--- a/infrastructure/team-dev/aws/us/cluster/outputs.tf
+++ b/infrastructure/team-dev/aws/us/cluster/outputs.tf
@@ -1,0 +1,11 @@
+output "kubectl-bootstrap" {
+  value = "aws eks update-kubeconfig --name ${module.eks.cluster_name} --region ${data.aws_region.this_env.name} --profile ${local.region}"
+}
+
+output "routing_autoscaling_group_id" {
+  value = module.routing-nodes.node_group_autoscaling_group_names[0]
+}
+
+output "ingress_security_group_id" {
+  value = aws_security_group.lb-to-routing-nodes.id
+}

--- a/infrastructure/team-dev/aws/us/cluster/remote-states.tf
+++ b/infrastructure/team-dev/aws/us/cluster/remote-states.tf
@@ -1,0 +1,26 @@
+data "terraform_remote_state" "routing" {
+  backend = "remote"
+
+  config = {
+    organization = "scaleout"
+    workspaces = {
+      name = "scaleout-platform-routing"
+    }
+  }
+}
+
+data "terraform_remote_state" "network" {
+  backend = "remote"
+
+  config = {
+    organization = "scaleout"
+    workspaces = {
+      name = "aws-team-dev-us-network"
+    }
+  }
+}
+
+locals {
+  routing = data.terraform_remote_state.routing.outputs
+  network = data.terraform_remote_state.network.outputs
+}

--- a/infrastructure/team-dev/aws/us/cluster/security-groups.tf
+++ b/infrastructure/team-dev/aws/us/cluster/security-groups.tf
@@ -1,0 +1,8 @@
+resource "aws_security_group" "lb-to-routing-nodes" {
+  name        = "${local.envName}-lb-to-routing-nodes"
+  description = "Allow inbound traffic to routing nodes."
+  vpc_id      = local.network.vpc.vpc_id
+  tags = {
+    Name = "${local.envName}-lb-to-routing-nodes"
+  }
+}

--- a/infrastructure/team-dev/aws/us/cluster/security-groups.tf
+++ b/infrastructure/team-dev/aws/us/cluster/security-groups.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "lb-to-routing-nodes" {
   name        = "${local.envName}-lb-to-routing-nodes"
   description = "Allow inbound traffic to routing nodes."
-  vpc_id      = local.network.vpc.vpc_id
+  vpc_id      = local.network.vpc_id
   tags = {
     Name = "${local.envName}-lb-to-routing-nodes"
   }

--- a/infrastructure/team-dev/aws/us/network/.terraform.lock.hcl
+++ b/infrastructure/team-dev/aws/us/network/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.45.0"
+  constraints = "5.45.0"
+  hashes = [
+    "h1:4Vgk51R7iTY1oczaTQDG+DkA9nE8TmjlUtecqXX6qDU=",
+    "zh:1379bcf45aef3d486ee18b4f767bfecd40a0056510d26107f388be3d7994c368",
+    "zh:1615a6f5495acfb3a0cb72324587261dd4d72711a3cc51aff13167b14531501e",
+    "zh:18b69a0f33f8b1862fbd3f200756b7e83e087b73687085f2cf9c7da4c318e3e6",
+    "zh:2c5e7aecd197bc3d3b19290bad8cf4c390c2c6a77bb165da4e11f53f2dfe2e54",
+    "zh:3794da9bef97596e3bc60e12cdd915bda5ec2ed62cd1cd93723d58b4981905fe",
+    "zh:40a5e45ed91801f83db76dffd467dcf425ea2ca8642327cf01119601cb86021c",
+    "zh:4abfc3f53d0256a7d5d1fa5e931e4601b02db3d1da28f452341d3823d0518f1a",
+    "zh:4eb0e98078f79aeb06b5ff6115286dc2135d12a80287885698d04036425494a2",
+    "zh:75470efbadea4a8d783642497acaeec5077fc4a7f3df3340defeaa1c7de29bf7",
+    "zh:8861a0b4891d5fa2fa7142f236ae613cea966c45b5472e3915a4ac3abcbaf487",
+    "zh:8bf6f21cd9390b742ca0b4393fde92616ca9e6553fb75003a0999006ad233d35",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ad73008a044e75d337acda910fb54d8b81a366873c8a413fec1291034899a814",
+    "zh:bf261713b0b8bebfe8c199291365b87d9043849f28a2dc764bafdde73ae43693",
+    "zh:da3bafa1fd830be418dfcc730e85085fe67c0d415c066716f2ac350a2306f40a",
+  ]
+}

--- a/infrastructure/team-dev/aws/us/network/config.tf
+++ b/infrastructure/team-dev/aws/us/network/config.tf
@@ -9,6 +9,12 @@ locals {
   envName   = "${local.provider}-${local.team}-${local.env}-${local.region}"
   name      = "${local.envName}-${local.workspace}"
   tags      = {}
+  network = {
+    // https://www.davidc.net/sites/default/subnets/subnets.html?network=10.10.0.0&mask=20&division=13.3d40
+    cidr            = "10.10.0.0/20"
+    private_subnets = ["10.10.0.0/22", "10.10.4.0/22", "10.10.8.0/22"],
+    public_subnets  = ["10.10.12.0/24", "10.10.13.0/24", "10.10.14.0/24"]
+  }
 }
 
 terraform {

--- a/infrastructure/team-dev/aws/us/network/config.tf
+++ b/infrastructure/team-dev/aws/us/network/config.tf
@@ -1,0 +1,33 @@
+data "aws_region" "this_env" {}
+
+locals {
+  provider  = "aws"
+  team      = "team"
+  env       = "dev"
+  region    = "us"
+  workspace = "network"
+  envName   = "${local.provider}-${local.team}-${local.env}-${local.region}"
+  name      = "${local.envName}-${local.workspace}"
+  tags      = {}
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "=5.45"
+    }
+  }
+  cloud {
+    organization = "scaleout"
+    workspaces {
+      project = "aws-team-dev-us"
+      name    = "aws-team-dev-us-network"
+    }
+  }
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  profile = "us"
+}

--- a/infrastructure/team-dev/aws/us/network/endpoints.tf
+++ b/infrastructure/team-dev/aws/us/network/endpoints.tf
@@ -1,0 +1,44 @@
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = module.vpc.vpc_id
+  service_name      = "com.amazonaws.${data.aws_region.this_env.name}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids = concat(
+    module.vpc.public_route_table_ids,
+    module.vpc.private_route_table_ids,
+    module.vpc.database_route_table_ids
+  )
+}
+
+resource "aws_vpc_endpoint" "ecr_api" {
+  vpc_id            = module.vpc.vpc_id
+  service_name      = "com.amazonaws.${data.aws_region.this_env.name}.ecr.api"
+  vpc_endpoint_type = "Interface"
+  security_group_ids = [
+    aws_security_group.vpc_interface_ingress.id,
+  ]
+  subnet_ids          = module.vpc.private_subnets
+  private_dns_enabled = true
+}
+
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  vpc_id            = module.vpc.vpc_id
+  service_name      = "com.amazonaws.${data.aws_region.this_env.name}.ecr.dkr"
+  vpc_endpoint_type = "Interface"
+  security_group_ids = [
+    aws_security_group.vpc_interface_ingress.id,
+  ]
+  subnet_ids          = module.vpc.private_subnets
+  private_dns_enabled = true
+}
+
+resource "aws_security_group" "vpc_interface_ingress" {
+  vpc_id = module.vpc.vpc_id
+  name   = "${module.vpc.name}-vpc-interface-ingress"
+
+  tags = merge(local.tags, {
+    Name = "${module.vpc.name}-vpc-interface-ingress"
+  })
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}

--- a/infrastructure/team-dev/aws/us/network/outputs.tf
+++ b/infrastructure/team-dev/aws/us/network/outputs.tf
@@ -1,0 +1,3 @@
+output "vpc" {
+  value = module.vpc
+}

--- a/infrastructure/team-dev/aws/us/network/outputs.tf
+++ b/infrastructure/team-dev/aws/us/network/outputs.tf
@@ -1,3 +1,19 @@
-output "vpc" {
-  value = module.vpc
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "public_subnets" {
+  value = module.vpc.public_subnets
+}
+
+output "private_subnets" {
+  value = module.vpc.private_subnets
+}
+
+output "public_subnets_cidr_blocks" {
+  value = module.vpc.public_subnets_cidr_blocks
+}
+
+output "private_subnets_cidr_blocks" {
+  value = module.vpc.private_subnets_cidr_blocks
 }

--- a/infrastructure/team-dev/aws/us/network/vpc.tf
+++ b/infrastructure/team-dev/aws/us/network/vpc.tf
@@ -1,50 +1,37 @@
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 5.7"
-
-  name = local.name
-  cidr = "10.10.0.0/20"
-
-  azs = ["${data.aws_region.this_env.name}a", "${data.aws_region.this_env.name}b", "${data.aws_region.this_env.name}c"]
-
-  # for slice up info see: https://www.davidc.net/sites/default/subnets/subnets.html?network=10.10.0.0&mask=20&division=25.3d9cc40
-  private_subnets  = ["10.10.0.0/22", "10.10.4.0/22", "10.10.8.0/22"]
-  database_subnets = ["10.10.12.0/25", "10.10.12.128/25", "10.10.13.0/25"]
-  # reserved for something in future: 10.10.13.128/25 10.10.14.0/25 10.10.14.128/25
-  public_subnets = ["10.10.15.0/26", "10.10.15.64/26", "10.10.15.128/26"] #10.10.15.192/26 left over
-
-  create_database_subnet_group = false
-
-  manage_default_network_acl = true
-  default_network_acl_tags   = { Name = "acl-${local.name}-default" }
-
-  manage_default_route_table = true
-  default_route_table_tags   = { Name = "rtb-${local.name}-default" }
-
-  manage_default_security_group = true
-  default_security_group_tags   = { Name = "sg-${local.name}-default" }
-
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-
-  enable_nat_gateway     = true
-  single_nat_gateway     = false
-  one_nat_gateway_per_az = true
-
+  name    = local.name
+  azs = [
+    "${data.aws_region.this_env.name}a",
+    "${data.aws_region.this_env.name}b",
+    "${data.aws_region.this_env.name}c"
+  ]
+  cidr            = local.network.cidr
+  private_subnets = local.network.private_subnets
+  public_subnets  = local.network.public_subnets
   public_subnet_tags = {
     "kubernetes.io/role/elb" = 1
   }
-
   private_subnet_tags = {
     "kubernetes.io/role/internal-elb" = 1
   }
-
-  enable_vpn_gateway = false
-
+  create_database_subnet_group         = false
+  manage_default_network_acl           = true
+  default_network_acl_tags             = { Name = "${local.envName}-default" }
+  manage_default_route_table           = true
+  default_route_table_tags             = { Name = "${local.envName}-default" }
+  manage_default_security_group        = true
+  default_security_group_tags          = { Name = "${local.envName}-default" }
+  enable_dns_hostnames                 = true
+  enable_dns_support                   = true
+  enable_nat_gateway                   = true
+  single_nat_gateway                   = false
+  one_nat_gateway_per_az               = true
+  enable_vpn_gateway                   = false
   enable_flow_log                      = true
   create_flow_log_cloudwatch_log_group = true
   create_flow_log_cloudwatch_iam_role  = true
   flow_log_max_aggregation_interval    = 60
-
-  tags = local.tags
+  tags                                 = local.tags
 }

--- a/infrastructure/team-dev/aws/us/network/vpc.tf
+++ b/infrastructure/team-dev/aws/us/network/vpc.tf
@@ -1,0 +1,50 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.7"
+
+  name = local.name
+  cidr = "10.10.0.0/20"
+
+  azs = ["${data.aws_region.this_env.name}a", "${data.aws_region.this_env.name}b", "${data.aws_region.this_env.name}c"]
+
+  # for slice up info see: https://www.davidc.net/sites/default/subnets/subnets.html?network=10.10.0.0&mask=20&division=25.3d9cc40
+  private_subnets  = ["10.10.0.0/22", "10.10.4.0/22", "10.10.8.0/22"]
+  database_subnets = ["10.10.12.0/25", "10.10.12.128/25", "10.10.13.0/25"]
+  # reserved for something in future: 10.10.13.128/25 10.10.14.0/25 10.10.14.128/25
+  public_subnets = ["10.10.15.0/26", "10.10.15.64/26", "10.10.15.128/26"] #10.10.15.192/26 left over
+
+  create_database_subnet_group = false
+
+  manage_default_network_acl = true
+  default_network_acl_tags   = { Name = "acl-${local.name}-default" }
+
+  manage_default_route_table = true
+  default_route_table_tags   = { Name = "rtb-${local.name}-default" }
+
+  manage_default_security_group = true
+  default_security_group_tags   = { Name = "sg-${local.name}-default" }
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  enable_nat_gateway     = true
+  single_nat_gateway     = false
+  one_nat_gateway_per_az = true
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = 1
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = 1
+  }
+
+  enable_vpn_gateway = false
+
+  enable_flow_log                      = true
+  create_flow_log_cloudwatch_log_group = true
+  create_flow_log_cloudwatch_iam_role  = true
+  flow_log_max_aggregation_interval    = 60
+
+  tags = local.tags
+}

--- a/infrastructure/team-dev/aws/us/routing/.terraform.lock.hcl
+++ b/infrastructure/team-dev/aws/us/routing/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.45.0"
+  constraints = "5.45.0"
+  hashes = [
+    "h1:4Vgk51R7iTY1oczaTQDG+DkA9nE8TmjlUtecqXX6qDU=",
+    "zh:1379bcf45aef3d486ee18b4f767bfecd40a0056510d26107f388be3d7994c368",
+    "zh:1615a6f5495acfb3a0cb72324587261dd4d72711a3cc51aff13167b14531501e",
+    "zh:18b69a0f33f8b1862fbd3f200756b7e83e087b73687085f2cf9c7da4c318e3e6",
+    "zh:2c5e7aecd197bc3d3b19290bad8cf4c390c2c6a77bb165da4e11f53f2dfe2e54",
+    "zh:3794da9bef97596e3bc60e12cdd915bda5ec2ed62cd1cd93723d58b4981905fe",
+    "zh:40a5e45ed91801f83db76dffd467dcf425ea2ca8642327cf01119601cb86021c",
+    "zh:4abfc3f53d0256a7d5d1fa5e931e4601b02db3d1da28f452341d3823d0518f1a",
+    "zh:4eb0e98078f79aeb06b5ff6115286dc2135d12a80287885698d04036425494a2",
+    "zh:75470efbadea4a8d783642497acaeec5077fc4a7f3df3340defeaa1c7de29bf7",
+    "zh:8861a0b4891d5fa2fa7142f236ae613cea966c45b5472e3915a4ac3abcbaf487",
+    "zh:8bf6f21cd9390b742ca0b4393fde92616ca9e6553fb75003a0999006ad233d35",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ad73008a044e75d337acda910fb54d8b81a366873c8a413fec1291034899a814",
+    "zh:bf261713b0b8bebfe8c199291365b87d9043849f28a2dc764bafdde73ae43693",
+    "zh:da3bafa1fd830be418dfcc730e85085fe67c0d415c066716f2ac350a2306f40a",
+  ]
+}

--- a/infrastructure/team-dev/aws/us/routing/config.tf
+++ b/infrastructure/team-dev/aws/us/routing/config.tf
@@ -1,0 +1,31 @@
+locals {
+  provider  = "aws"
+  team      = "team"
+  env       = "dev"
+  region    = "us"
+  workspace = "routing"
+  envName   = "${local.provider}-${local.team}-${local.env}-${local.region}"
+  name      = "${local.envName}-${local.workspace}"
+  tags      = {}
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "=5.45"
+    }
+  }
+  cloud {
+    organization = "scaleout"
+    workspaces {
+      project = "aws-team-dev-us"
+      name    = "aws-team-dev-us-routing"
+    }
+  }
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  profile = "us"
+}

--- a/infrastructure/team-dev/aws/us/routing/dns-public.tf
+++ b/infrastructure/team-dev/aws/us/routing/dns-public.tf
@@ -1,0 +1,21 @@
+resource "aws_route53_record" "public_apex" {
+  zone_id = local.routing.zone_id
+  name    = local.routing.domain
+  type    = "A"
+  alias {
+    name                   = aws_lb.public_ingress.dns_name
+    zone_id                = aws_lb.public_ingress.zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "public_star" {
+  zone_id = local.routing.zone_id
+  name    = "*.${local.routing.domain}"
+  type    = "A"
+  alias {
+    name                   = aws_lb.public_ingress.dns_name
+    zone_id                = aws_lb.public_ingress.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/infrastructure/team-dev/aws/us/routing/hack/nginx.yml
+++ b/infrastructure/team-dev/aws/us/routing/hack/nginx.yml
@@ -3,10 +3,18 @@ kind: Namespace
 metadata:
   name: routing
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-html
+  namespace: routing
+data:
+  index.html: aws-us
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-deployment
+  name: nginx
   namespace: routing
 spec:
   selector:
@@ -18,11 +26,18 @@ spec:
       labels:
         app: nginx
     spec:
+      volumes:
+      - name: nginx-html
+        configMap:
+          name: nginx-html
       containers:
       - name: nginx
         image: nginx:1.25.4
         ports:
         - containerPort: 80
+        volumeMounts:
+        - mountPath: /usr/share/nginx/html
+          name: nginx-html
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/infrastructure/team-dev/aws/us/routing/hack/nginx.yml
+++ b/infrastructure/team-dev/aws/us/routing/hack/nginx.yml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: routing
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: routing
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.25.4
+        ports:
+        - containerPort: 80
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - nginx
+            topologyKey: failure-domain.beta.kubernetes.io/zone
+      nodeSelector:
+        node.wescaleout.cloud/routing: "true"
+      tolerations:
+      - key: node.wescaleout.cloud/routing
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx
+  namespace: routing
+spec:
+  type: NodePort
+  selector:
+    app: nginx
+  ports:
+    - name: health
+      protocol: "TCP"
+      port: 30877
+      nodePort: 30877
+      targetPort: 80
+    - name: http
+      protocol: "TCP"
+      port: 31080
+      nodePort: 31080
+      targetPort: 80

--- a/infrastructure/team-dev/aws/us/routing/ingress-public.tf
+++ b/infrastructure/team-dev/aws/us/routing/ingress-public.tf
@@ -1,0 +1,136 @@
+resource "aws_lb" "public_ingress" {
+  name         = "lb-${local.name}"
+  subnets      = local.network.vpc.public_subnets
+  idle_timeout = 130
+  security_groups = [
+    aws_security_group.public_ingress.id
+  ]
+  tags = merge(local.tags, {
+    Name = "lb-${local.name}"
+  })
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "aws_lb_target_group" "public_ingress" {
+  name     = "${local.name}-ingress"
+  port     = 31080
+  protocol = "HTTP"
+  vpc_id   = local.network.vpc.vpc_id
+  stickiness {
+    type    = "lb_cookie"
+    enabled = false
+  }
+  /*
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+    protocol            = "HTTP"
+    port                = 30877
+    path                = "/"
+    interval            = 60
+  }
+  */
+}
+
+data "aws_eks_node_group" "routing" {
+  cluster_name    = local.envName
+  node_group_name = "${local.envName}-routing"
+}
+
+resource "aws_autoscaling_attachment" "public_ingress" {
+  lb_target_group_arn    = aws_lb_target_group.public_ingress.arn
+  autoscaling_group_name = data.aws_eks_node_group.routing.resources[0].autoscaling_groups[0].name
+}
+
+resource "aws_lb_listener" "public_ingress_nonsecure" {
+  load_balancer_arn = aws_lb.public_ingress.arn
+  port              = 80
+  protocol          = "HTTP"
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+resource "aws_lb_listener" "public_ingress" {
+  load_balancer_arn = aws_lb.public_ingress.arn
+  port              = 443
+  protocol          = "HTTPS"
+  certificate_arn   = local.routing.certificate_arn
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.public_ingress.arn
+  }
+}
+
+// hide endpoints
+resource "aws_lb_listener_rule" "public_ingress_prevent_public" {
+  for_each = {
+    metrics = {
+      status_code  = 404
+      message_body = "Not Found"
+    },
+    health = {
+      status_code  = 404
+      message_body = "Not Found"
+    },
+    liveness = {
+      status_code  = 404
+      message_body = "Not Found"
+    }
+    readiness = {
+      status_code  = 404
+      message_body = "Not Found"
+    }
+  }
+  listener_arn = aws_lb_listener.public_ingress.arn
+  action {
+    type = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = each.value.message_body
+      status_code  = each.value.status_code
+    }
+  }
+  condition {
+    path_pattern {
+      values = [format("/%s", each.key)]
+    }
+  }
+}
+
+resource "aws_security_group" "public_ingress" {
+  name   = "${local.name}-world-to-lb"
+  vpc_id = local.network.vpc.vpc_id
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = merge(local.tags, {
+    Name = "${local.name}-world-to-lb"
+  })
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}

--- a/infrastructure/team-dev/aws/us/routing/ingress-public.tf
+++ b/infrastructure/team-dev/aws/us/routing/ingress-public.tf
@@ -1,6 +1,6 @@
 resource "aws_lb" "public_ingress" {
   name         = local.name
-  subnets      = local.network.vpc.public_subnets
+  subnets      = local.network.public_subnets
   idle_timeout = 130
   security_groups = [
     aws_security_group.public_ingress.id
@@ -17,7 +17,7 @@ resource "aws_lb_target_group" "public_ingress" {
   name     = "${local.name}-ingress"
   port     = 31080
   protocol = "HTTP"
-  vpc_id   = local.network.vpc.vpc_id
+  vpc_id   = local.network.vpc_id
   stickiness {
     type    = "lb_cookie"
     enabled = false
@@ -108,7 +108,7 @@ resource "aws_lb_listener_rule" "public_ingress_prevent_public" {
 
 resource "aws_security_group" "public_ingress" {
   name   = "${local.name}-world-to-lb"
-  vpc_id = local.network.vpc.vpc_id
+  vpc_id = local.network.vpc_id
   egress {
     from_port   = 0
     to_port     = 0

--- a/infrastructure/team-dev/aws/us/routing/ingress-public.tf
+++ b/infrastructure/team-dev/aws/us/routing/ingress-public.tf
@@ -1,12 +1,12 @@
 resource "aws_lb" "public_ingress" {
-  name         = "lb-${local.name}"
+  name         = local.name
   subnets      = local.network.vpc.public_subnets
   idle_timeout = 130
   security_groups = [
     aws_security_group.public_ingress.id
   ]
   tags = merge(local.tags, {
-    Name = "lb-${local.name}"
+    Name = local.name
   })
   lifecycle {
     ignore_changes = [tags]

--- a/infrastructure/team-dev/aws/us/routing/ingress-public.tf
+++ b/infrastructure/team-dev/aws/us/routing/ingress-public.tf
@@ -22,7 +22,6 @@ resource "aws_lb_target_group" "public_ingress" {
     type    = "lb_cookie"
     enabled = false
   }
-  /*
   health_check {
     healthy_threshold   = 2
     unhealthy_threshold = 2
@@ -32,7 +31,6 @@ resource "aws_lb_target_group" "public_ingress" {
     path                = "/"
     interval            = 60
   }
-  */
 }
 
 data "aws_eks_node_group" "routing" {

--- a/infrastructure/team-dev/aws/us/routing/remote-states.tf
+++ b/infrastructure/team-dev/aws/us/routing/remote-states.tf
@@ -1,0 +1,38 @@
+data "terraform_remote_state" "routing" {
+  backend = "remote"
+
+  config = {
+    organization = "scaleout"
+    workspaces = {
+      name = "scaleout-platform-team-dev-routing"
+    }
+  }
+}
+
+data "terraform_remote_state" "network" {
+  backend = "remote"
+
+  config = {
+    organization = "scaleout"
+    workspaces = {
+      name = "aws-team-dev-us-network"
+    }
+  }
+}
+
+data "terraform_remote_state" "cluster" {
+  backend = "remote"
+
+  config = {
+    organization = "scaleout"
+    workspaces = {
+      name = "aws-team-dev-us-cluster"
+    }
+  }
+}
+
+locals {
+  routing = data.terraform_remote_state.routing.outputs.aws-us
+  network = data.terraform_remote_state.network.outputs
+  cluster = data.terraform_remote_state.cluster.outputs
+}

--- a/infrastructure/team-dev/aws/us/routing/security-groups.tf
+++ b/infrastructure/team-dev/aws/us/routing/security-groups.tf
@@ -1,0 +1,17 @@
+resource "aws_security_group_rule" "eks_cluster_lb_ingress" {
+  type                     = "ingress"
+  from_port                = 31080
+  to_port                  = 31080
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.public_ingress.id
+  security_group_id        = local.cluster.ingress_security_group_id
+}
+
+resource "aws_security_group_rule" "eks_cluster_lb_health_ingress" {
+  type                     = "ingress"
+  from_port                = 30877
+  to_port                  = 30877
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.public_ingress.id
+  security_group_id        = local.cluster.ingress_security_group_id
+}


### PR DESCRIPTION
This PR suggests a base configuration for AWS clusters and includes complete configuration for one cluster in the US and one cluster in Australia. When running, they show the default nginx home page at the following:
https://aws-us.team.dev.wescaleout.cloud
https://aws-au.team.dev.wescaleout.cloud

Also included is a `bin/cluster` script to orchestrate creating and destroying clusters and a `Makefile` to orchestration creation and destruction of all clusters.

Once we are happy with this we can decide how we want to handle north/south traffic at the following (non-functional) endpoints:
https://us.team.dev.wescaleout.cloud
https://au.team.dev.wescaleout.cloud
https://aws.team.dev.wescaleout.cloud